### PR TITLE
SSL verification_mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Specifies the output configuration to Elasticsearch without Security enabled.
           username: auditbeat_writer
           password: pa$$word
           protocol: https
+	  verification_mode: certificate
           ssl_certificate_authorities:
             - "/etc/ca/my_ca.crt"
 
@@ -144,9 +145,9 @@ Example Playbook
   become: yes
   vars:
     auditbeat_service:
-      install_path_windows32: "C:\\Program Files\\monitoring\\winlogbeat"
-      install_path_windows64: "C:\\Program Files\\monitoring\\winlogbeat"
-      version: "7.6.0"
+      install_path_windows32: "C:\\Program Files\\monitoring\\auditbeat"
+      install_path_windows64: "C:\\Program Files\\monitoring\\auditbeat"
+      version: "7.9.3"
       download: true
       install_rules: true
     auditbeat_template:

--- a/templates/auditbeat-windows.yml.j2
+++ b/templates/auditbeat-windows.yml.j2
@@ -71,6 +71,9 @@ output.elasticsearch:
 {% if auditbeat_output.elasticsearch.security.ssl_certificate_authorities is defined %}
   ssl.certificate_authorities: {{ auditbeat_output.elasticsearch.security.ssl_certificate_authorities | to_json }}
 {% endif %}
+{% if 'https' == auditbeat_output.elasticsearch.security.protocol  %}
+  ssl.verification_mode: {{ auditbeat_output.elasticsearch.security.ssl.verification_mode | default("full") }}
+{% endif %}
 {% endif %}
 {% endif %}
 {% if auditbeat_output.type == "logstash" %}
@@ -84,6 +87,7 @@ output.logstash:
   # List of root certificates for HTTPS server verifications
   ssl.certificate_authorities: {{ auditbeat_output.logstash.security.ssl_certificate_authorities | to_json }}
 {% endif %}
+
 {% endif %}
 {% if auditbeat_output.type == "redis" %}
 #------------------------------ Redis output ---------------------------------

--- a/templates/auditbeat.yml.j2
+++ b/templates/auditbeat.yml.j2
@@ -85,6 +85,9 @@ output.elasticsearch:
 {% if auditbeat_output.elasticsearch.security.ssl_certificate_authorities is defined %}
   ssl.certificate_authorities: {{ auditbeat_output.elasticsearch.security.ssl_certificate_authorities | to_json }}
 {% endif %}
+{% if 'https' == auditbeat_output.elasticsearch.security.protocol  %}
+  ssl.verification_mode: {{ auditbeat_output.elasticsearch.security.ssl.verification_mode | default("full") }}
+{% endif %}
 {% endif %}
 {% endif %}
 {% if auditbeat_output.type == "logstash" %}


### PR DESCRIPTION
- Fix typos in README.md
- Add `ssl.verification_mode` option to elasticsearch output when `protocol` is HTTPS as suggested by #13 
- Add `verification_mode` to example in README.md