### PR TITLE
Add ssl key/cert for ssl authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ Specifies the output configuration to Elasticsearch without Security enabled.
 
 Specifies the output configuration to Elasticsearch with security enabled, certificate authority must be present on server.
 
+    auditbeat_ssl_key_file: my-logstash.p8
+    auditbeat_ssl_certificate_file: my-logstash.crt
+    auditbeat_ssl_insecure: True
+    auditbeat_output:
+      type: elasticsearch
+      elasticsearch:
+        hosts:
+          - "localhost:9200"
+        ssl:
+          certificate_authorities: "{{ auditbeat_ssl_certificate_file }}"
+          certificate: "{{ auditbeat_ssl_certificate_file }}"
+          key: "{{ auditbeat_ssl_key_file }}"
+          insecure: "{{ auditbeat_ssl_insecure }}"
+
+Specifies the output configuration to Elasticsoarch with ssl authentication enabled, Logstash can be configured in the same way.
+
 Variable `auditbeat_output.type` takes three values either `logstash`, `elasticsearch` or `redis`. This is because if you have ansible `hash_behaviour` set to `merge` role would install both elasticsearch and logstash outputs when using logstash output type which is wrong.
 
 Example of Redis output:

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Specifies the output configuration to Elasticsearch without Security enabled.
 
 Specifies the output configuration to Elasticsearch with security enabled, certificate authority must be present on server.
 
-    auditbeat_ssl_key_file: my-logstash.p8
-    auditbeat_ssl_certificate_file: my-logstash.crt
+    auditbeat_ssl_key_file: my-ssl.p8
+    auditbeat_ssl_certificate_file: my-ssl.crt
     auditbeat_ssl_insecure: True
     auditbeat_output:
       type: elasticsearch

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,9 @@ auditbeat_processors: |
   - add_host_metadata: ~
   - add_cloud_metadata: ~
   - add_docker_metadata: ~
+
+auditbeat_ssl_dir: /etc/pki/auditbeat
+auditbeat_ssl_key_file: ""
+auditbeat_ssl_certificate_file: ""
+auditbeat_ssl_certificate_authorities: ""
+auditbeat_ssl_insecure: "false"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,28 @@
   when: ansible_os_family == "RedHat"
   tags: install
 
+- name: Ensure Auditbeat SSL key pair directory exists.
+  file:
+    path: "{{ auditbeat_ssl_dir }}"
+    state: directory
+    mode: 0755
+  when: auditbeat_ssl_key_file | default(false)
+
+- name: Copy SSL key and cert for auditbeat.
+  copy:
+    src: "{{ item }}"
+    dest: "{{ auditbeat_ssl_dir }}/{{ item | basename }}"
+    mode: 0644
+  loop:
+    - "{{ auditbeat_ssl_key_file }}"
+    - "{{ auditbeat_ssl_certificate_file }}"
+    - "{{ auditbeat_ssl_certificate_authorities_file }}"
+  notify: restart-auditbeat
+  when:
+    - auditbeat_ssl_key_file | default(false)
+    - auditbeat_ssl_certificate_file | default(false)
+    - auditbeat_ssl_certificate_authorities_file | default(false)
+
 - name: (Linux) Create auditbeat configuration file
   template:
     src: auditbeat.yml.j2

--- a/templates/auditbeat.yml.j2
+++ b/templates/auditbeat.yml.j2
@@ -82,6 +82,13 @@ output.elasticsearch:
   username: {{ auditbeat_output.elasticsearch.security.username }}
   password: {{ auditbeat_output.elasticsearch.security.password }}
   protocol: {{ auditbeat_output.elasticsearch.security.protocol }}
+{% if 'ssl' in auditbeat_output.elasticsearch %}
+  ssl:
+{% if 'certificate_authorities' in auditbeat_output.elasticsearch.ssl %}    certificate_authorities: {{ auditbeat_ssl_dir }}/{{ auditbeat_output.elasticsearch.ssl.certificate_authorities | basename }} {% endif %} 
+    certificate: {{ auditbeat_ssl_dir }}/{{ auditbeat_output.elasticsearch.ssl.certificate | basename }}
+    key: {{ auditbeat_ssl_dir }}/{{ auditbeat_output.elasticsearch.ssl.key | basename }}
+    insecure: {{ auditbeat_output.elasticsearch.ssl.insecure }}
+{% endif %}
 {% if auditbeat_output.elasticsearch.security.ssl_certificate_authorities is defined %}
   ssl.certificate_authorities: {{ auditbeat_output.elasticsearch.security.ssl_certificate_authorities | to_json }}
 {% endif %}
@@ -96,6 +103,13 @@ output.logstash:
   # The Logstash hosts
   hosts: {{ auditbeat_output.logstash.hosts | to_json }}
 
+{% if 'ssl' in auditbeat_output.logstash %}
+  ssl:
+{% if 'certificate_authorities' in auditbeat_output.logstash.ssl %}    certificate_authorities: {{ auditbeat_ssl_dir }}/{{ auditbeat_output.logstash.ssl.certificate_authorities | basename }} {% endif %} 
+    certificate: {{ auditbeat_ssl_dir }}/{{ auditbeat_output.logstash.ssl.certificate | basename }}
+    key: {{ auditbeat_ssl_dir }}/{{ auditbeat_output.logstash.ssl.key | basename }}
+    insecure: {{ auditbeat_output.logstash.ssl.insecure }}
+{% endif %}
 {% if auditbeat_output.logstash.security.ssl_certificate_authorities is defined %}}
   # Optional SSL. By default is off.
   # List of root certificates for HTTPS server verifications


### PR DESCRIPTION
Adds certificate and key for ssl authentication, previous method only supported certificate_authorities and didn't copy the files needed to the host.