### PR TITLE
Gentoo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Auditbeat should also work on Oracle Enterprise Linux but only with RHCK.
 
 \* Auditbeat on Windows supports different set of features. If you wish to achieve similar functionality use Sysmon + Winlogbeat
 
-\*\* If you want to run auditbeat on Gentoo, you will need to create your own ebuild, if you want to use the `system` metricset, you will need to build auditbeat with x-pack folder with the elastic licence.
+\*\* If you want to run auditbeat on Gentoo, you will need to create your own ebuild, if you want to use the `system` metricset, you will need to build auditbeat with x-pack folder with the elastic licence. If you want to use Sockets, you will need Kprobe enabled in your kernel's menuconfig
 
 If you wish to run Auditbeat from docker container use the official docker [image](https://hub.docker.com/_/auditbeat) provided by Elastic.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An Ansible role that replaces auditd with Auditbeat. Included modified version o
 
 Please test the rules properly before using on production. Some rules may cause performance impact depending on your setup. For more information on Auditbeat please visit the official [documentation](https://www.elastic.co/guide/en/beats/auditbeat/current/auditbeat-overview.html)
 
-Supported platfroms:
+Supported platforms:
 - Ubuntu 20.04
 - Ubuntu 18.04
 - Ubuntu 16.04
@@ -22,6 +22,7 @@ Supported platfroms:
 - Debian 10
 - Debian 9
 - Debian 8
+- Gentoo \*\*
 - Windows 10\*
 - Windows Server 2019\*
 - Windows Server 2016\*
@@ -29,6 +30,8 @@ Supported platfroms:
 Auditbeat should also work on Oracle Enterprise Linux but only with RHCK.
 
 \* Auditbeat on Windows supports different set of features. If you wish to achieve similar functionality use Sysmon + Winlogbeat
+
+\*\* If you want to run auditbeat on Gentoo, you will need to create your own ebuild, if you want to use the `system` metricset, you will need to build auditbeat with x-pack folder with the elastic licence.
 
 If you wish to run Auditbeat from docker container use the official docker [image](https://hub.docker.com/_/auditbeat) provided by Elastic.
 
@@ -61,6 +64,9 @@ Ansible variables from `defaults/main.yml`
       - add_host_metadata: ~
       - add_cloud_metadata: ~
       - add_docker_metadata: ~
+    auditbeat_portage:
+      package: =auditbeat-{{ auditbeat_service.version }}
+      getbinpkg: no
 
 The `auditbeat_service.install_rules` can be changed to false if you don't want to use the rules included.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,7 @@ auditbeat_processors: |
   - add_host_metadata: ~
   - add_cloud_metadata: ~
   - add_docker_metadata: ~
+
+auditbeat_portage:
+  package: =auditbeat-{{ auditbeat_service.version }}
+  getbinpkg: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,7 @@
   when:
     - ansible_facts.services['auditd'] is defined
     - ansible_os_family != "Windows"
+    - ansible_os_family != "Gentoo"
   tags: install
 
 - name: (Debian/Ubuntu) Install auditbeat apt
@@ -51,6 +52,14 @@
     name: auditbeat-{{ auditbeat_service.version }}
     state: present
   when: ansible_os_family == "RedHat"
+  tags: install
+
+# INFO: Based on where and how you generate your auditbeat portage package, you may need to change the package name
+- name: (Gentoo) Install auditbeat portage
+  community.general.portage:
+    package: "{{ auditbeat_portage.package }}"
+    getbinpkg: "{{ auditbeat_portage.getbinpkg }}"
+  when: ansible_os_family == "Gentoo"
   tags: install
 
 - name: (Linux) Create auditbeat configuration file


### PR DESCRIPTION
This PR adds the ability to install auditbeat on Gentoo using portage.

This does leave the task of actually building auditbeat to the user. I separated the portage logic into its own variables to account for any custom name being made by the auditbeat ebuild for that environment.

I have also added some notes about a common issue to using auditbeat on Gentoo in relation to the files protected by the elastic license.

Signed-off-by: Ryan Walter <ryan.walter@sectigo.com>