### PR TITLE
Jinja v2.10 renamed indentfirst to indent

### DIFF
--- a/templates/auditbeat-windows.yml.j2
+++ b/templates/auditbeat-windows.yml.j2
@@ -107,7 +107,7 @@ output.redis:
 
 {% if auditbeat_processors is defined %}
 processors:
-{{ auditbeat_processors | indent( width=2, indentfirst=True) }}
+  {{ auditbeat_processors | indent( width=2 ) }}
 {% endif %}
 
 #============================== X-Pack Monitoring ===============================

--- a/templates/auditbeat.yml.j2
+++ b/templates/auditbeat.yml.j2
@@ -120,7 +120,7 @@ output.redis:
 
 {% if auditbeat_processors is defined %}
 processors:
-{{ auditbeat_processors | indent( width=2, indentfirst=True) }}
+  {{ auditbeat_processors | indent( width=2 ) }}
 {% endif %}
 
 #============================== X-Pack Monitoring ===============================


### PR DESCRIPTION
Instead of trying to enforce versions of jinja on users include the indentation of the first line and accept the other defaults of indent

```
fatal: [hostname]: FAILED! => {"changed": false, "msg": "AnsibleError: Unexpected templating type error occurred on (# Managed by Ansible\n...............................................: do_indent() got an unexpected keyword argument 'indentfirst'"}
```